### PR TITLE
Add drag-and-drop widgets

### DIFF
--- a/dragdrop.py
+++ b/dragdrop.py
@@ -1,0 +1,56 @@
+from PySide6.QtWidgets import QLineEdit, QFileDialog
+from PySide6.QtCore import Qt, Signal
+import os
+
+class DragDropField(QLineEdit):
+    """Read-only line edit supporting drag and drop and double click selection."""
+
+    pathChanged = Signal(str)
+
+    def __init__(self, mode: str = "file", parent=None):
+        super().__init__(parent)
+        self.mode = mode  # "file" or "folder"
+        self.setReadOnly(True)
+        self.setAcceptDrops(True)
+        placeholder = "Перетащите {} или двойной клик".format(
+            "файл" if self.mode == "file" else "папку"
+        )
+        self.setPlaceholderText(placeholder)
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasUrls():
+            path = event.mimeData().urls()[0].toLocalFile()
+            if self._valid_path(path):
+                event.acceptProposedAction()
+                return
+        event.ignore()
+
+    def dropEvent(self, event):
+        if event.mimeData().hasUrls():
+            path = event.mimeData().urls()[0].toLocalFile()
+            if self._valid_path(path):
+                self.setText(path)
+                self.pathChanged.emit(path)
+                event.acceptProposedAction()
+                return
+        event.ignore()
+
+    def mouseDoubleClickEvent(self, event):
+        if self.mode == "folder":
+            folder = QFileDialog.getExistingDirectory(self, "Выберите папку")
+            if folder:
+                self.setText(folder)
+                self.pathChanged.emit(folder)
+        else:
+            file, _ = QFileDialog.getOpenFileName(self, "Выберите файл")
+            if file:
+                self.setText(file)
+                self.pathChanged.emit(file)
+        super().mouseDoubleClickEvent(event)
+
+    def _valid_path(self, path: str) -> bool:
+        return (
+            os.path.isdir(path)
+            if self.mode == "folder"
+            else os.path.isfile(path)
+        )

--- a/gui.py
+++ b/gui.py
@@ -1,9 +1,20 @@
 import sys
 import logging
 from PySide6.QtWidgets import (
-    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
-    QFileDialog, QTabWidget, QLineEdit, QMessageBox, QLabel
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QFileDialog,
+    QTabWidget,
+    QLineEdit,
+    QMessageBox,
+    QLabel,
 )
+
+from dragdrop import DragDropField
 
 from converter import export_to_word, import_from_word
 
@@ -13,24 +24,18 @@ logger = logging.getLogger(__name__)
 class ExportTab(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.eng_folder = ""
-        self.rus_folder = ""
         layout = QVBoxLayout()
 
         hbox_eng = QHBoxLayout()
-        self.eng_folder_edit = QLineEdit()
-        btn_select_eng = QPushButton("Выбрать папку с английскими файлами")
-        btn_select_eng.clicked.connect(self.select_eng_folder)
+        self.eng_folder_edit = DragDropField(mode="folder")
+        hbox_eng.addWidget(QLabel("Папка с английскими файлами:"))
         hbox_eng.addWidget(self.eng_folder_edit)
-        hbox_eng.addWidget(btn_select_eng)
         layout.addLayout(hbox_eng)
 
         hbox_rus = QHBoxLayout()
-        self.rus_folder_edit = QLineEdit()
-        btn_select_rus = QPushButton("Выбрать папку с русскими файлами")
-        btn_select_rus.clicked.connect(self.select_rus_folder)
+        self.rus_folder_edit = DragDropField(mode="folder")
+        hbox_rus.addWidget(QLabel("Папка с русскими файлами:"))
         hbox_rus.addWidget(self.rus_folder_edit)
-        hbox_rus.addWidget(btn_select_rus)
         layout.addLayout(hbox_rus)
 
         hbox_encoding = QHBoxLayout()
@@ -46,28 +51,25 @@ class ExportTab(QWidget):
 
         self.setLayout(layout)
 
-    def select_eng_folder(self):
-        folder = QFileDialog.getExistingDirectory(self, "Выберите папку с английскими файлами")
-        if folder:
-            self.eng_folder = folder
-            self.eng_folder_edit.setText(folder)
-
-    def select_rus_folder(self):
-        folder = QFileDialog.getExistingDirectory(self, "Выберите папку с русскими файлами")
-        if folder:
-            self.rus_folder = folder
-            self.rus_folder_edit.setText(folder)
-
     def do_export(self):
-        if not self.eng_folder or not self.rus_folder:
+        eng_folder = self.eng_folder_edit.text().strip()
+        rus_folder = self.rus_folder_edit.text().strip()
+        if not eng_folder or not rus_folder:
             QMessageBox.warning(self, "Ошибка", "Сначала выберите обе папки с файлами")
             return
         rus_enc = self.encoding_edit.text().strip() or None
-        output_path, _ = QFileDialog.getSaveFileName(self, "Сохранить Word документ", "", "Word файлы (*.docx)")
+        output_path, _ = QFileDialog.getSaveFileName(
+            self, "Сохранить Word документ", "", "Word файлы (*.docx)"
+        )
         if not output_path:
             return
         try:
-            export_to_word(self.eng_folder, self.rus_folder, output_path, rus_force_encoding=rus_enc)
+            export_to_word(
+                eng_folder,
+                rus_folder,
+                output_path,
+                rus_force_encoding=rus_enc,
+            )
             QMessageBox.information(self, "Успех", "Word документ успешно создан!")
         except Exception as exc:
             logger.exception("Export failed")
@@ -77,33 +79,24 @@ class ExportTab(QWidget):
 class ImportTab(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.word_file = ""
-        self.eng_output_folder = ""
-        self.rus_output_folder = ""
         layout = QVBoxLayout()
 
         hbox_word = QHBoxLayout()
-        self.word_file_edit = QLineEdit()
-        btn_select_word = QPushButton("Выбрать Word документ")
-        btn_select_word.clicked.connect(self.select_word_file)
+        self.word_file_edit = DragDropField(mode="file")
+        hbox_word.addWidget(QLabel("Word документ:"))
         hbox_word.addWidget(self.word_file_edit)
-        hbox_word.addWidget(btn_select_word)
         layout.addLayout(hbox_word)
 
         hbox_eng = QHBoxLayout()
-        self.eng_output_edit = QLineEdit()
-        btn_select_eng_out = QPushButton("Папка для английских файлов")
-        btn_select_eng_out.clicked.connect(self.select_eng_output)
+        self.eng_output_edit = DragDropField(mode="folder")
+        hbox_eng.addWidget(QLabel("Папка для английских файлов:"))
         hbox_eng.addWidget(self.eng_output_edit)
-        hbox_eng.addWidget(btn_select_eng_out)
         layout.addLayout(hbox_eng)
 
         hbox_rus = QHBoxLayout()
-        self.rus_output_edit = QLineEdit()
-        btn_select_rus_out = QPushButton("Папка для русских файлов")
-        btn_select_rus_out.clicked.connect(self.select_rus_output)
+        self.rus_output_edit = DragDropField(mode="folder")
+        hbox_rus.addWidget(QLabel("Папка для русских файлов:"))
         hbox_rus.addWidget(self.rus_output_edit)
-        hbox_rus.addWidget(btn_select_rus_out)
         layout.addLayout(hbox_rus)
 
         btn_import = QPushButton("Разбить Word документ")
@@ -112,30 +105,19 @@ class ImportTab(QWidget):
 
         self.setLayout(layout)
 
-    def select_word_file(self):
-        file, _ = QFileDialog.getOpenFileName(self, "Выберите Word документ", "", "Word файлы (*.docx)")
-        if file:
-            self.word_file = file
-            self.word_file_edit.setText(file)
-
-    def select_eng_output(self):
-        folder = QFileDialog.getExistingDirectory(self, "Выберите папку для английских файлов")
-        if folder:
-            self.eng_output_folder = folder
-            self.eng_output_edit.setText(folder)
-
-    def select_rus_output(self):
-        folder = QFileDialog.getExistingDirectory(self, "Выберите папку для русских файлов")
-        if folder:
-            self.rus_output_folder = folder
-            self.rus_output_edit.setText(folder)
-
     def do_import(self):
-        if not self.word_file or not self.eng_output_folder or not self.rus_output_folder:
-            QMessageBox.warning(self, "Ошибка", "Сначала выберите Word документ и папки для сохранения файлов")
+        word_file = self.word_file_edit.text().strip()
+        eng_output = self.eng_output_edit.text().strip()
+        rus_output = self.rus_output_edit.text().strip()
+        if not word_file or not eng_output or not rus_output:
+            QMessageBox.warning(
+                self,
+                "Ошибка",
+                "Сначала выберите Word документ и папки для сохранения файлов",
+            )
             return
         try:
-            import_from_word(self.word_file, self.eng_output_folder, self.rus_output_folder)
+            import_from_word(word_file, eng_output, rus_output)
             QMessageBox.information(self, "Успех", "Файлы успешно сохранены!")
         except Exception as exc:
             logger.exception("Import failed")


### PR DESCRIPTION
## Summary
- create `DragDropField` widget handling drag and drop
- integrate `DragDropField` into export/import tabs

## Testing
- `python -m py_compile *.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687043c98948832ca2d29c3f2f256d90